### PR TITLE
Implemented a faster HtmlTokenizer using ui4j

### DIFF
--- a/libpay-2checkout-htmltokenizer/pom.xml
+++ b/libpay-2checkout-htmltokenizer/pom.xml
@@ -39,6 +39,13 @@
         </developer>
     </developers>
 
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>com.wix.pay</groupId>
@@ -51,9 +58,9 @@
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-            <version>${htmlunit.version}</version>
+            <groupId>com.github.ui4j.ui4j.ui4j-all</groupId>
+            <artifactId>ui4j-all</artifactId>
+            <version>${com.github.ui4j.ui4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/libpay-2checkout-htmltokenizer/src/main/scala/com/wix/pay/twocheckout/tokenization/html/HtmlTokenizer.scala
+++ b/libpay-2checkout-htmltokenizer/src/main/scala/com/wix/pay/twocheckout/tokenization/html/HtmlTokenizer.scala
@@ -2,7 +2,8 @@ package com.wix.pay.twocheckout.tokenization.html
 
 import java.net.URLEncoder
 
-import com.gargoylesoftware.htmlunit.{AlertHandler, Page, WebClient}
+import com.ui4j.api.browser.{BrowserFactory, PageConfiguration}
+import com.ui4j.api.dialog.{AlertHandler, DialogEvent}
 import com.wix.pay.creditcard.CreditCard
 import com.wix.pay.twocheckout.model.Environments
 import com.wix.pay.twocheckout.model.html.{Error, TokenizeResponse}
@@ -10,6 +11,8 @@ import com.wix.pay.twocheckout.tokenization.TwocheckoutTokenizer
 import org.json4s.DefaultFormats
 import org.json4s.native.Serialization
 
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Promise}
 import scala.util.Try
 
 object JavascriptSdkUrls {
@@ -20,54 +23,55 @@ object JavascriptSdkUrls {
   * [[TwocheckoutTokenizer]] that uses 2checkout's official JavaScript SDK inside a headless browser.
   */
 class HtmlTokenizer(jsSdkUrl: String = JavascriptSdkUrls.production,
-                    environment: String = Environments.production) extends TwocheckoutTokenizer {
-  override def tokenize(sellerId: String, publishableKey: String, card: CreditCard): Try[String] = {
-    Try {
-      val webClient = new WebClient
-      webClient.getOptions.setCssEnabled(false)
-      webClient.getJavaScriptEngine.getContextFactory.enterContext().setOptimizationLevel(9)
+                    environment: String = Environments.production) extends TwocheckoutTokenizer with AutoCloseable {
+  private val browser = BrowserFactory.getWebKit
 
-      try {
-        var alertMessage: Option[String] = None
-        webClient.setAlertHandler(new AlertHandler {
-          override def handleAlert(page: Page, s: String): Unit = {
-            alertMessage = Option(s)
-          }
-        })
+  override def tokenize(sellerId: String, publishableKey: String, card: CreditCard): Try[String] = Try {
+    val alertMessage: Promise[String] = Promise()
 
-        val tokenizeHtml = HtmlTokenizer.createTokenizeHtml(
-          jsSdkUrl = jsSdkUrl,
-          environment = environment,
-          sellerId = sellerId,
-          publishableKey = publishableKey,
-          card = card
-        )
+    val tokenizeHtml = HtmlTokenizer.createTokenizeHtml(
+      jsSdkUrl = jsSdkUrl,
+      environment = environment,
+      sellerId = sellerId,
+      publishableKey = publishableKey,
+      card = card
+    )
 
-        webClient.getPage(s"data:text/html,${URLEncoder.encode(tokenizeHtml, "UTF-8")}")
-
-        val responseJson = alertMessage.get
-        val response = HtmlTokenizer.parseHtmlTokenizerResponseJson(responseJson)
-        (response.error, response.value) match {
-          case (Some(error), _) =>
-            throw new RuntimeException(s"${error.errorCode}|${error.errorMsg}")
-          case (None, Some(value)) =>
-            value.response.token.token
-          case _ => throw new IllegalStateException(s"Tokenize HTML returned unexpected response format: $responseJson")
-        }
-
-      } finally {
-        webClient.close()
+    val configuration = new PageConfiguration()
+    configuration.setAlertHandler(new AlertHandler() {
+      override def handle(event: DialogEvent) = {
+        alertMessage.success(event.getMessage)
       }
+    })
+
+    // URLEncoder encodes as www-form-urlencoded, where space is '+' and not '%20'
+    val data = URLEncoder.encode(tokenizeHtml, "UTF-8").replace("+", "%20")
+    val page = browser.navigate(s"data:text/html;charset=utf-8,$data", configuration)
+
+    try {
+      val responseJson = Await.result(alertMessage.future, atMost = Duration("10s"))
+      val response = HtmlTokenizer.parseHtmlTokenizerResponseJson(responseJson)
+      (response.error, response.value) match {
+        case (Some(error), _) =>
+          throw new RuntimeException(s"${error.errorCode}|${error.errorMsg}")
+        case (None, Some(value)) =>
+          value.response.token.token
+        case _ => throw new IllegalStateException(s"Tokenize HTML returned unexpected response format: $responseJson")
+      }
+    } finally {
+      page.close()
     }
   }
+
+  override def close(): Unit = browser.shutdown()
 }
 
 private object HtmlTokenizer {
   private implicit val formats = DefaultFormats
 
   /**
-    * @param value   Success value (None on error).
-    * @param error   Error value (None on success).
+    * @param value Success value (None on error).
+    * @param error Error value (None on success).
     */
   case class HtmlTokenizerResponse(value: Option[TokenizeResponse], error: Option[Error])
 

--- a/libpay-2checkout-parent/pom.xml
+++ b/libpay-2checkout-parent/pom.xml
@@ -69,7 +69,7 @@
         <org.json4js.version>3.4.0</org.json4js.version>
         <com.wix.pay.libpay.version>1.3.0-SNAPSHOT</com.wix.pay.libpay.version>
         <commons.codec.version>1.10</commons.codec.version>
-        <htmlunit.version>2.24</htmlunit.version>
+        <com.github.ui4j.ui4j.version>2.2.0</com.github.ui4j.ui4j.version>
         <httpcomponents.version>4.5.2</httpcomponents.version>
     </properties>
 </project>


### PR DESCRIPTION
Tokenization now takes ~800ms instead of ~5s in the previous implementation using HtmlUnit.

There is one open issue: It logs the data that it is loading through JUL, the data is url-encoded but includes the public/private tokens. 

Also, the internal implementation depends on JavaFx, I think it manipulates a JavaFx scene graph as it is loading the page.